### PR TITLE
Add license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Project Manager -- a plugin for gedit
+Copyright (C) 2008 Jeff Shipley (2008)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/README
+++ b/README
@@ -5,21 +5,7 @@ Enable the plugin named Project Manager
 
 ----------
 
-Project Manager -- a plugin for gedit
-Copyright (C) 2008 Jeff Shipley (2008)
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+GPLv3 - See License file
 
 ----------
 


### PR DESCRIPTION
Hey, came across this project earlier today and noticed it didn't have a license file and thus Github didn't recognize the license associated with it. I've moved your license block from your README to a license file and updated the README to reflect the new license file. This should hopefully allow Github to recognize the license associated with this repo. Thanks!